### PR TITLE
feat: add kafka producer for new user profile initialization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,9 @@ dependencies {
     implementation 'org.mapstruct:mapstruct:1.6.3'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
+
+    // kafka
+    implementation 'org.springframework.kafka:spring-kafka'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/itmentorcommunityplatform/authservice/auth/TelegramAuthService.java
+++ b/src/main/java/com/itmentorcommunityplatform/authservice/auth/TelegramAuthService.java
@@ -2,6 +2,7 @@ package com.itmentorcommunityplatform.authservice.auth;
 
 import com.itmentorcommunityplatform.authservice.entity.Role;
 import com.itmentorcommunityplatform.authservice.entity.User;
+import com.itmentorcommunityplatform.authservice.kafka.AuthEventProducer;
 import com.itmentorcommunityplatform.authservice.mapper.UserMapper;
 import com.itmentorcommunityplatform.authservice.repository.RoleRepository;
 import com.itmentorcommunityplatform.authservice.repository.UserRepository;
@@ -22,6 +23,7 @@ public class TelegramAuthService {
     private final UserRepository userRepository;
     private final UserRoleRepository userRoleRepository;
     private final UserMapper userMapper;
+    private final AuthEventProducer kafkaEventProducer;
 
     @Value("${telegram.init-data-expiration-seconds}")
     private long expirationSeconds;
@@ -59,6 +61,8 @@ public class TelegramAuthService {
         newUser.setTelegramUserId(telegramUserId);
         User saved = userRepository.save(newUser);
         log.info("New user created with id={}", saved.getId());
+        kafkaEventProducer.sendUserCreated(telegramUserId);
+        log.info("A message about creating the new user was sent to kafka.");
         return saved;
     }
 }

--- a/src/main/java/com/itmentorcommunityplatform/authservice/internalUser/InternalUserService.java
+++ b/src/main/java/com/itmentorcommunityplatform/authservice/internalUser/InternalUserService.java
@@ -2,6 +2,7 @@ package com.itmentorcommunityplatform.authservice.internalUser;
 
 import com.itmentorcommunityplatform.authservice.entity.Role;
 import com.itmentorcommunityplatform.authservice.entity.User;
+import com.itmentorcommunityplatform.authservice.kafka.AuthEventProducer;
 import com.itmentorcommunityplatform.authservice.repository.RoleRepository;
 import com.itmentorcommunityplatform.authservice.repository.UserRepository;
 import com.itmentorcommunityplatform.authservice.repository.UserRoleRepository;
@@ -19,6 +20,7 @@ public class InternalUserService {
     private final UserRepository userRepository;
     private final RoleRepository roleRepository;
     private final UserRoleRepository userRoleRepository;
+    private final AuthEventProducer kafkaEventProducer;
 
     @Transactional
     public InternalUserResultUpsertDto upsertUser(UserUpsertRequestDto requestDto) {
@@ -56,6 +58,11 @@ public class InternalUserService {
         var rolesId = roles.stream().map(r -> r.getId()).toList();
         userRoleRepository.insertUserRole(user.getId(), rolesId);
         log.info("User_id and Roles_id were insert to Users_Roles table successfully.");
+
+        if (created) {
+            kafkaEventProducer.sendUserCreated(telegramId);
+            log.info("A message about creating the new user was sent to kafka.");
+        }
 
         return new InternalUserResultUpsertDto(user.getTelegramUserId(), created);
     }

--- a/src/main/java/com/itmentorcommunityplatform/authservice/kafka/AuthEventProducer.java
+++ b/src/main/java/com/itmentorcommunityplatform/authservice/kafka/AuthEventProducer.java
@@ -1,0 +1,20 @@
+package com.itmentorcommunityplatform.authservice.kafka;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthEventProducer {
+
+     private final KafkaTemplate<String, Object> kafkaTemplate;
+
+     @Value("${kafka.topic.auth-user-created}")
+     private String authUserCreatedTopic;
+
+     public void sendUserCreated(long telegramUserId) {
+         kafkaTemplate.send(authUserCreatedTopic, new UserCreatedEvent(telegramUserId));
+     }
+}

--- a/src/main/java/com/itmentorcommunityplatform/authservice/kafka/KafkaTopicsConfig.java
+++ b/src/main/java/com/itmentorcommunityplatform/authservice/kafka/KafkaTopicsConfig.java
@@ -1,0 +1,20 @@
+package com.itmentorcommunityplatform.authservice.kafka;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+@Configuration
+public class KafkaTopicsConfig {
+
+    @Value("${kafka.topic.auth-user-created}")
+    private String authUserCreatedTopic;
+
+    @Bean
+    public NewTopic authUserCreatedTopic() {
+        return TopicBuilder.name(authUserCreatedTopic)
+                .build();
+    }
+}

--- a/src/main/java/com/itmentorcommunityplatform/authservice/kafka/UserCreatedEvent.java
+++ b/src/main/java/com/itmentorcommunityplatform/authservice/kafka/UserCreatedEvent.java
@@ -1,0 +1,7 @@
+package com.itmentorcommunityplatform.authservice.kafka;
+
+public record UserCreatedEvent (
+
+        long telegram_user_id
+
+) {}

--- a/src/main/resources/application-ide.yml
+++ b/src/main/resources/application-ide.yml
@@ -6,6 +6,15 @@ spring:
     driver-class-name: org.postgresql.Driver
   liquibase:
     change-log: classpath:/db/changelog/db.changelog-master.yml
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:29092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+
+kafka:
+  topic:
+    auth-user-created: auth.user.created
 
 telegram:
   bot-token: ${TELEGRAM_BOT_TOKEN:open test token}

--- a/src/main/resources/application-local-stack.yml
+++ b/src/main/resources/application-local-stack.yml
@@ -6,6 +6,15 @@ spring:
     driver-class-name: org.postgresql.Driver
   liquibase:
     change-log: classpath:/db/changelog/db.changelog-master.yml
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+
+kafka:
+  topic:
+    auth-user-created: auth.user.created
 
 telegram:
   bot-token: ${TELEGRAM_BOT_TOKEN:open test token}


### PR DESCRIPTION
Add Kafka integration to send user creation events when new users register through Telegram authentication or internal user service. This includes adding the necessary dependencies, creating event producer and configuration classes, and updating service logic to publish messages to the auth.user.created topic.