### PR TITLE
Feature new claim in jwt 42

### DIFF
--- a/requestHttp/DummyAuthTest.http
+++ b/requestHttp/DummyAuthTest.http
@@ -1,4 +1,4 @@
-### Dummy User  — Successful request
+### Dummy User  — Successful request 200
 POST http://localhost:8080/api/auth/by-dummy
 Content-Type: application/json
 

--- a/requestHttp/TelegramAuthTest.http
+++ b/requestHttp/TelegramAuthTest.http
@@ -1,5 +1,4 @@
-
-### Telegram Auth — Successful request
+### Telegram Auth — Successful request 200
 // Для тестирования использовать bot-token бота и воспользоваться инитДатой которую можно получить по этой ссылке - https://t.me/testtesttest111122233_bot/getdata
 POST http://localhost:8080/api/auth/by-telegram
 Content-Type: text/plain
@@ -8,16 +7,16 @@ user=%7B%22id%22%3A628570951%2C%22first_name%22%3A%22llqq%22%2C%22last_name%22%3
 
 ###
 
-### Telegram Auth — Missing hash
+
+### Telegram Auth — Missing hash 500
 POST http://localhost:8080/api/auth/by-telegram
 Content-Type: text/plain
 
 user=%7B%22id%22%3A628570951%2C%22first_name%22%3A%22llqq%22%2C%22last_name%22%3A%22%22%2C%22username%22%3A%22llllqqqqq2%2C%22language_code%22%3A%22ru%22%2C%22allows_write_to_pm%22%3Atrue%2C%22photo_url%22%3A%22https%3A%5C%2F%5C%2Ft.me%5C%2zRmbIeFTEMtE.svg%22%7D&chat_instanc46433238170020&chat_type=private&auth_date=1762334768&signature=BXVyC3y3tKYcaaHAm7ggLJjEXi5hXeRnT2_qBkGjhXfeSPfnr8oC_aBU07WKEASXyyyrtmaYqH6EY0vw4-NTBQ&hash=4ed8d735fca82fa7a5976943b6bb1e787cebaf9750c75f416a11d9151fc85f1a
 
-
 ###
 
-### Telegram Auth — Invalid hash
+### Telegram Auth — Invalid hash 500
 POST http://localhost:8080/api/auth/by-telegram
 Content-Type: text/plain
 
@@ -26,7 +25,7 @@ user=%7B%22id%22%3A628570951%2C%22first_name%22%3A%22llqq%22%2C%22last_name%22%3
 
 ###
 
-### Telegram Auth — Malformed JSON in user
+### Telegram Auth — Malformed JSON in user 400
 POST http://localhost:8080/api/auth/by-telegram
 Content-Type: text/plain
 
@@ -34,7 +33,7 @@ use%22ru%22%2C%22allows_write_to_pm%22%3Atrue%2C%22photo_url%22%3A%22https%3A%5C
 
 ###
 
-### Telegram Auth — Expired auth_date
+### Telegram Auth — Expired auth_date 400
 POST http://localhost:8080/api/auth/by-telegram
 Content-Type: text/plain
 
@@ -42,8 +41,10 @@ user=%7B%22id%22%3A628570951%2C%22first_name%22%3A%22llqq%22%2C%22last_name%22%3
 
 ###
 
-### Telegram Auth — Simulated internal server error
+### Telegram Auth — Simulated internal server error 400
 POST http://localhost:8080/api/auth/by-telegram
 Content-Type: text/plain
 
 user=TRIGGER_INTERNAL_ERROR
+
+###

--- a/src/main/java/com/itmentorcommunityplatform/authservice/auth/JwtService.java
+++ b/src/main/java/com/itmentorcommunityplatform/authservice/auth/JwtService.java
@@ -1,5 +1,6 @@
 package com.itmentorcommunityplatform.authservice.auth;
 
+import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,15 +25,26 @@ public class JwtService {
         this.expirationMillis = expirationMillis * 60 * 1000;
     }
 
-    public String generateToken(Long telegramUserId, List<String> roles) {
+    public String generateToken(Long userId, List<String> roles, String telegramUsername) {
         long now = System.currentTimeMillis();
         Date issuedAt = new Date(now);
         Date expiration = new Date(now + expirationMillis);
-        return Jwts.builder()
-                .subject(String.valueOf(telegramUserId))
-                .claim("roles", roles).issuedAt(issuedAt)
+
+        JwtBuilder builder = Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claim("roles", roles)
+                .issuedAt(issuedAt)
                 .expiration(expiration)
-                .signWith(key)
-                .compact();
+                .signWith(key);
+
+        if (telegramUsername != null && !telegramUsername.trim().isEmpty()) {
+            builder.claim("telegram_username", telegramUsername);
+        }
+
+        return builder.compact();
+    }
+
+    public String generateToken(Long userId, List<String> roles) {
+        return generateToken(userId, roles, null);
     }
 }

--- a/src/main/java/com/itmentorcommunityplatform/authservice/auth/TelegramAuthService.java
+++ b/src/main/java/com/itmentorcommunityplatform/authservice/auth/TelegramAuthService.java
@@ -1,10 +1,8 @@
 package com.itmentorcommunityplatform.authservice.auth;
 
-import com.itmentorcommunityplatform.authservice.entity.Role;
 import com.itmentorcommunityplatform.authservice.entity.User;
 import com.itmentorcommunityplatform.authservice.kafka.AuthEventProducer;
 import com.itmentorcommunityplatform.authservice.mapper.UserMapper;
-import com.itmentorcommunityplatform.authservice.repository.RoleRepository;
 import com.itmentorcommunityplatform.authservice.repository.UserRepository;
 import com.itmentorcommunityplatform.authservice.repository.UserRoleRepository;
 import lombok.RequiredArgsConstructor;
@@ -32,7 +30,8 @@ public class TelegramAuthService {
     public AuthResponseDto authenticateByTelegram(String initData) {
         try {
             log.info("Starting Telegram authentication process...");
-            Long telegramUserId = validator.extractUserFromInitData(initData, expirationSeconds);
+            Long telegramUserId = validator.extractTelegramUserIdFromInitData(initData, expirationSeconds);
+            String telegramUsername = validator.extractTelegramUsernameFromInitData(initData, expirationSeconds);
             log.info("InitData validated successfully for telegramUserId={}", telegramUserId);
 
             User user = userRepository.findByTelegramUserId(telegramUserId)
@@ -41,7 +40,7 @@ public class TelegramAuthService {
             var userRoles = userRoleRepository.findRolesByUserId(user.getId());
             log.info("User Roles = {}",userRoles);
 
-            String token = jwtService.generateToken(telegramUserId,userRoles);
+            String token = jwtService.generateToken(telegramUserId, userRoles, telegramUsername);
             log.info("JWT token generated for userId={}", user.getId());
 
             UserResponseDto userResponseDto = userMapper.toDto(user);

--- a/src/main/java/com/itmentorcommunityplatform/authservice/auth/TelegramAuthService.java
+++ b/src/main/java/com/itmentorcommunityplatform/authservice/auth/TelegramAuthService.java
@@ -30,8 +30,10 @@ public class TelegramAuthService {
     public AuthResponseDto authenticateByTelegram(String initData) {
         try {
             log.info("Starting Telegram authentication process...");
-            Long telegramUserId = validator.extractTelegramUserIdFromInitData(initData, expirationSeconds);
-            String telegramUsername = validator.extractTelegramUsernameFromInitData(initData, expirationSeconds);
+            var telegramInitData = validator.validateAndParse(initData, expirationSeconds);
+            String telegramUsername = telegramInitData.telegramUsername();
+            Long telegramUserId = telegramInitData.telegramUserId();
+
             log.info("InitData validated successfully for telegramUserId={}", telegramUserId);
 
             User user = userRepository.findByTelegramUserId(telegramUserId)

--- a/src/main/java/com/itmentorcommunityplatform/authservice/auth/TelegramInitData.java
+++ b/src/main/java/com/itmentorcommunityplatform/authservice/auth/TelegramInitData.java
@@ -1,0 +1,7 @@
+package com.itmentorcommunityplatform.authservice.auth;
+
+public record TelegramInitData(
+        Long telegramUserId,
+        String telegramUsername
+) {
+}

--- a/src/main/java/com/itmentorcommunityplatform/authservice/auth/TelegramInitDataValidator.java
+++ b/src/main/java/com/itmentorcommunityplatform/authservice/auth/TelegramInitDataValidator.java
@@ -25,23 +25,18 @@ public class TelegramInitDataValidator {
     @Value("${telegram.bot-token}")
     private String botToken;
 
-    public Long extractTelegramUserIdFromInitData(String initData, long expirationSeconds) throws InvalidInitDataException {
-        Map<String, String> data = parseInitData(initData);
-
-        validateHash(data);
-        validateAuthDate(data, expirationSeconds);
-
-        long telegramUserId = extractTelegramUserId(data);
-        return telegramUserId;
-    }
-
-    public String extractTelegramUsernameFromInitData(
-            String initData, long expirationSeconds
-    ) throws InvalidInitDataException {
+    public TelegramInitData validateAndParse(String initData, long expirationSeconds)
+            throws InvalidInitDataException {
         Map<String, String> data = parseInitData(initData);
         validateHash(data);
         validateAuthDate(data, expirationSeconds);
-        return extractTelegramUsername(data);
+
+        Long telegramUserId = extractTelegramUserId(data);
+        String telegramUsername = extractTelegramUsername(data);
+
+        log.info("Successfully parsed Telegram initData: userId={}, username={}",
+                telegramUserId, telegramUsername);
+        return new TelegramInitData(telegramUserId, telegramUsername);
     }
 
     private Map<String, String> parseInitData(String initData) {

--- a/src/main/java/com/itmentorcommunityplatform/authservice/auth/TelegramInitDataValidator.java
+++ b/src/main/java/com/itmentorcommunityplatform/authservice/auth/TelegramInitDataValidator.java
@@ -1,7 +1,7 @@
 package com.itmentorcommunityplatform.authservice.auth;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.itmentorcommunityplatform.authservice.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.digest.HmacAlgorithms;
@@ -25,7 +25,7 @@ public class TelegramInitDataValidator {
     @Value("${telegram.bot-token}")
     private String botToken;
 
-    public Long extractUserFromInitData(String initData, long expirationSeconds) throws InvalidInitDataException {
+    public Long extractTelegramUserIdFromInitData(String initData, long expirationSeconds) throws InvalidInitDataException {
         Map<String, String> data = parseInitData(initData);
 
         validateHash(data);
@@ -33,6 +33,15 @@ public class TelegramInitDataValidator {
 
         long telegramUserId = extractTelegramUserId(data);
         return telegramUserId;
+    }
+
+    public String extractTelegramUsernameFromInitData(
+            String initData, long expirationSeconds
+    ) throws InvalidInitDataException {
+        Map<String, String> data = parseInitData(initData);
+        validateHash(data);
+        validateAuthDate(data, expirationSeconds);
+        return extractTelegramUsername(data);
     }
 
     private Map<String, String> parseInitData(String initData) {
@@ -101,6 +110,23 @@ public class TelegramInitDataValidator {
             return objectMapper.readTree(userJson).get("id").asLong();
         } catch (Exception e) {
             throw new InvalidInitDataException("Invalid user JSON");
+        }
+    }
+
+    private String extractTelegramUsername(Map<String, String> data) {
+        try {
+            String userJson = data.get("user");
+            if (userJson == null)
+                return null;
+
+            JsonNode userNode = objectMapper.readTree(userJson);
+            if (userNode.has("username")) {
+                return userNode.get("username").asText(null);
+            }
+            return null;
+        } catch (Exception e) {
+            log.warn("Failed to extract username from user JSON", e);
+            return null;
         }
     }
 }

--- a/src/main/resources/application-ide.yml
+++ b/src/main/resources/application-ide.yml
@@ -24,6 +24,9 @@ jwt:
   secret: 632eca39fc29068edc74133ca9cf8f40b4942191f80c0c78dd588835beb5f57b
   expiration_minutes: 30
 
+server:
+  port: 8080
+
 management:
   endpoints:
     web:


### PR DESCRIPTION
1. **JWT claims**: 
   - Добавил опциональный claim `telegram_username` в `JwtService.generateToken()`
   - Обновил `TelegramInitDataValidator` — новый метод `extractTelegramUsername()`
   - В `/auth/by-telegram` теперь токен содержит `telegram_username` с валидным значением

2. **Порт для IDE профиля**:
   - В `application-ide.yaml` изменил `server.port: 8081 → 8080`