### PR TITLE
feat: user data updates (producer)

### DIFF
--- a/src/main/java/com/itmentorcommunityplatform/authservice/admin/AdminService.java
+++ b/src/main/java/com/itmentorcommunityplatform/authservice/admin/AdminService.java
@@ -4,6 +4,8 @@ import com.itmentorcommunityplatform.authservice.constant.Role;
 import com.itmentorcommunityplatform.authservice.dummyAuth.UserNotFoundException;
 import com.itmentorcommunityplatform.authservice.entity.User;
 import com.itmentorcommunityplatform.authservice.internalUser.InvalidRoleException;
+import com.itmentorcommunityplatform.authservice.kafka.AuthEventProducer;
+import com.itmentorcommunityplatform.authservice.kafka.UserAuthenticatedEvent;
 import com.itmentorcommunityplatform.authservice.repository.UserRepository;
 import com.itmentorcommunityplatform.authservice.repository.UserRoleRepository;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +24,7 @@ public class AdminService {
 
     private final UserRepository userRepository;
     private final UserRoleRepository userRoleRepository;
+    private final AuthEventProducer kafkaEventProducer;
 
     @Transactional
     public void changeUserRoles(Long telegramUserId,
@@ -49,6 +52,15 @@ public class AdminService {
         preventAdminRoleChange(userRoles, targetRoles);
 
         refreshUserRoles(userId, targetRoles);
+
+        publishUserRolesChangedEvent(telegramUserId, userId);
+    }
+
+    private void publishUserRolesChangedEvent(Long telegramUserId, Integer userId) {
+        List<String> updatedRoles = userRoleRepository.findRolesByUserId(userId);
+        kafkaEventProducer.sendUserAuthenticated(
+                new UserAuthenticatedEvent(telegramUserId, null, null, null, updatedRoles));
+        log.info("Successfully sent change roles message to kafka, for telegramUserId: {}, roles: {}", telegramUserId, updatedRoles);
     }
 
     private void refreshUserRoles(Integer userId, List<Role> targetRoles) {

--- a/src/main/java/com/itmentorcommunityplatform/authservice/admin/AdminService.java
+++ b/src/main/java/com/itmentorcommunityplatform/authservice/admin/AdminService.java
@@ -53,14 +53,14 @@ public class AdminService {
 
         refreshUserRoles(userId, targetRoles);
 
-        publishUserRolesChangedEvent(telegramUserId, userId);
+        publishUserRolesChangedEvent(telegramUserId, targetRoles);
     }
 
-    private void publishUserRolesChangedEvent(Long telegramUserId, Integer userId) {
-        List<String> updatedRoles = userRoleRepository.findRolesByUserId(userId);
+    private void publishUserRolesChangedEvent(Long telegramUserId, List<Role> targetRoles) {
+        List<String> rolesToPublish = targetRoles.stream().map(Role::name).distinct().toList();
         kafkaEventProducer.sendUserAuthenticated(
-                new UserAuthenticatedEvent(telegramUserId, null, null, null, updatedRoles));
-        log.info("Successfully sent change roles message to kafka, for telegramUserId: {}, roles: {}", telegramUserId, updatedRoles);
+                new UserAuthenticatedEvent(telegramUserId, null, null, null, rolesToPublish));
+        log.info("Successfully sent change roles message to kafka, for telegramUserId: {}, roles: {}", telegramUserId, targetRoles);
     }
 
     private void refreshUserRoles(Integer userId, List<Role> targetRoles) {

--- a/src/main/java/com/itmentorcommunityplatform/authservice/auth/TelegramAuthService.java
+++ b/src/main/java/com/itmentorcommunityplatform/authservice/auth/TelegramAuthService.java
@@ -3,7 +3,9 @@ package com.itmentorcommunityplatform.authservice.auth;
 import com.itmentorcommunityplatform.authservice.constant.Role;
 import com.itmentorcommunityplatform.authservice.entity.User;
 import com.itmentorcommunityplatform.authservice.kafka.AuthEventProducer;
+import com.itmentorcommunityplatform.authservice.kafka.UserAuthenticatedEvent;
 import com.itmentorcommunityplatform.authservice.kafka.UserCreatedEvent;
+import com.itmentorcommunityplatform.authservice.kafka.exception.KafkaSendException;
 import com.itmentorcommunityplatform.authservice.mapper.UserMapper;
 import com.itmentorcommunityplatform.authservice.repository.UserRepository;
 import com.itmentorcommunityplatform.authservice.repository.UserRoleRepository;
@@ -14,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -45,7 +48,9 @@ public class TelegramAuthService {
             String lastName = telegramInitData.lastName();
             log.info("InitData validated successfully for telegramUserId={}", telegramUserId);
 
-            UserRolesDto userRolesDto = userRepository.findUserRolesByTelegramUserId(telegramUserId)
+            Optional<UserRolesDto> existingUser = userRepository.findUserRolesByTelegramUserId(telegramUserId);
+            boolean isNewUser = existingUser.isEmpty();
+            UserRolesDto userRolesDto = existingUser
                     .orElseGet(() -> createNewUserWithRole(telegramUserId, telegramUsername, firstName, lastName));
 
             log.info("User Roles = {}", userRolesDto.roles());
@@ -54,11 +59,18 @@ public class TelegramAuthService {
             log.info("JWT token generated for userId={}", userRolesDto.id());
 
             UserResponseDto userResponseDto = userMapper.toResponseDto(userRolesDto);
+
+            if (!isNewUser) {
+                sendAuthenticationMessageToKafka(telegramUserId, telegramUsername, firstName, lastName, userRolesDto.roles());
+            }
             log.info("User successfully authenticated via Telegram");
 
             return new AuthResponseDto(token, userResponseDto);
         } catch (InvalidInitDataException e) {
             log.error("Telegram authentication failed: {}", e.getMessage());
+            throw e;
+        } catch (KafkaSendException e) {
+            log.error("Telegram authentication failed while sending message to kafka", e);
             throw e;
         } catch (Exception e) {
             throw new RuntimeException("Authentication failed", e);
@@ -69,10 +81,17 @@ public class TelegramAuthService {
         User saved = userRepository.save(new User(telegramUserId));
         log.info("New user created with id={}", saved.getId());
         kafkaEventProducer.sendUserCreated(new UserCreatedEvent(telegramUserId, telegramUsername, firstName, lastName));
-        log.info("A message about creating the new user was sent to kafka.");
+        log.info("Successfully sent creation message to kafka, for telegramUserId: {}", telegramUserId);
 
         List<String> roles = setRoles(saved, telegramUserId);
         return userMapper.toUserRolesDto(saved, roles);
+    }
+
+    private void sendAuthenticationMessageToKafka(Long telegramUserId, String telegramUsername,
+                                                  String firstName, String lastName, List<String> roles) {
+        kafkaEventProducer.sendUserAuthenticated(
+                new UserAuthenticatedEvent(telegramUserId, telegramUsername, firstName, lastName, roles));
+        log.info("Successfully sent authentication message to kafka, for telegramUserId: {}", telegramUserId);
     }
 
     private List<String> setRoles(User user, Long telegramUserId) {

--- a/src/main/java/com/itmentorcommunityplatform/authservice/kafka/AuthEventProducer.java
+++ b/src/main/java/com/itmentorcommunityplatform/authservice/kafka/AuthEventProducer.java
@@ -1,20 +1,50 @@
 package com.itmentorcommunityplatform.authservice.kafka;
 
+import com.itmentorcommunityplatform.authservice.kafka.exception.KafkaSendException;
 import lombok.RequiredArgsConstructor;
+import org.apache.kafka.common.errors.TimeoutException;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.KafkaException;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
+
+import java.util.concurrent.ExecutionException;
 
 @Service
 @RequiredArgsConstructor
 public class AuthEventProducer {
 
-     private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
 
-     @Value("${kafka.topic.auth-user-created}")
-     private String authUserCreatedTopic;
+    @Value("${kafka.topic.auth-user-created}")
+    private String authUserCreatedTopic;
 
-     public void sendUserCreated(UserCreatedEvent userCreatedEvent) {
-         kafkaTemplate.send(authUserCreatedTopic, userCreatedEvent);
-     }
+    @Value("${kafka.topic.auth-user-authenticated}")
+    private String authUserAuthenticatedTopic;
+
+    public void sendUserCreated(UserCreatedEvent userCreatedEvent) {
+        try {
+            kafkaTemplate.send(authUserCreatedTopic, userCreatedEvent).get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new KafkaSendException(
+                    "Thread interrupted while publishing to kafka creation event, telegramUserId: " + userCreatedEvent.telegramUserId(), e);
+        } catch (ExecutionException | KafkaException | TimeoutException e) {
+            throw new KafkaSendException(
+                    "Failed to publish kafka creation event, for telegramUserId: " + userCreatedEvent.telegramUserId(), e);
+        }
+    }
+
+    public void sendUserAuthenticated(UserAuthenticatedEvent userAuthenticatedEvent) {
+        try {
+            kafkaTemplate.send(authUserAuthenticatedTopic, userAuthenticatedEvent).get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new KafkaSendException(
+                    "Thread interrupted while publishing to kafka authentication event, telegramUserId: " + userAuthenticatedEvent.telegramUserId(), e);
+        } catch (ExecutionException | KafkaException | TimeoutException e) {
+            throw new KafkaSendException(
+                    "Failed to publish kafka authentication event, for telegramUserId: " + userAuthenticatedEvent.telegramUserId(), e);
+        }
+    }
 }

--- a/src/main/java/com/itmentorcommunityplatform/authservice/kafka/KafkaTopicsConfig.java
+++ b/src/main/java/com/itmentorcommunityplatform/authservice/kafka/KafkaTopicsConfig.java
@@ -12,9 +12,18 @@ public class KafkaTopicsConfig {
     @Value("${kafka.topic.auth-user-created}")
     private String authUserCreatedTopic;
 
+    @Value("${kafka.topic.auth-user-authenticated}")
+    private String authUserAuthenticatedTopic;
+
     @Bean
     public NewTopic authUserCreatedTopic() {
         return TopicBuilder.name(authUserCreatedTopic)
+                .build();
+    }
+
+    @Bean
+    public NewTopic authUserAuthenticatedTopic() {
+        return TopicBuilder.name(authUserAuthenticatedTopic)
                 .build();
     }
 }

--- a/src/main/java/com/itmentorcommunityplatform/authservice/kafka/UserAuthenticatedEvent.java
+++ b/src/main/java/com/itmentorcommunityplatform/authservice/kafka/UserAuthenticatedEvent.java
@@ -1,0 +1,19 @@
+package com.itmentorcommunityplatform.authservice.kafka;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record UserAuthenticatedEvent(
+
+        @JsonProperty("telegram_user_id")
+        long telegramUserId,
+        @JsonProperty("telegram_username")
+        String telegramUsername,
+        @JsonProperty("first_name")
+        String firstName,
+        @JsonProperty("last_name")
+        String lastName,
+        @JsonProperty("roles")
+        List<String> roles
+) {}

--- a/src/main/java/com/itmentorcommunityplatform/authservice/kafka/exception/KafkaSendException.java
+++ b/src/main/java/com/itmentorcommunityplatform/authservice/kafka/exception/KafkaSendException.java
@@ -1,0 +1,12 @@
+package com.itmentorcommunityplatform.authservice.kafka.exception;
+
+public class KafkaSendException extends RuntimeException {
+
+    public KafkaSendException(String message) {
+        super(message);
+    }
+
+    public KafkaSendException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/resources/application-local-stack.yml
+++ b/src/main/resources/application-local-stack.yml
@@ -6,9 +6,5 @@ spring:
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
 
-kafka:
-  topic:
-    auth-user-created: auth.user.created
-
 jwt:
   secret: 632eca39fc29068edc74133ca9cf8f40b4942191f80c0c78dd588835beb5f57b

--- a/src/main/resources/application-staging.yml
+++ b/src/main/resources/application-staging.yml
@@ -16,6 +16,7 @@ spring:
 kafka:
   topic:
     auth-user-created: staging.auth.user.created
+    auth-user-authenticated: staging.auth.user.authenticated
 
 jwt:
   secret: ${JWT_SECRET}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,10 +7,20 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      acks: 1
+      retries: 3
+      properties:
+        max.block.ms: 30000
+        request.timeout.ms: 10000
+        delivery.timeout.ms: 30000
+        reconnect.backoff.ms: 1000
+        reconnect.backoff.max.ms: 10000
+        linger.ms: 5
 
 kafka:
   topic:
     auth-user-created: auth.user.created
+    auth-user-authenticated: auth.user.authenticated
 
 telegram:
   init-data-expiration-seconds: 1800


### PR DESCRIPTION
- добавлен топик auth.user.authenticated (в который отсылаются сообщения как на авторизацию (без регистрации), так и при смене роли)
- добавлены настройки producer - если в течении 30с не удастся отправить сообщение в кафку - выбросится ошибка и тем самым, пользователь не будет бесконечно ждать пока кафка восстановится (как и занимаемый им поток)
- синхронизировал отправку сообщений в кафку на создание и авторизацию юзера - из соображений, что если сообщение не попадет в кафку, то и авторизировать/регистрировать юзера, не имеет смысла
- при обновлении роли - данные для отправки, получаю еще одним запросом в БД, сделал так, для большей безопасности + транзакция таже и соединение уже открыто, соответственно накладные расходы не большие